### PR TITLE
Use URI.open intead of Kernel#open

### DIFF
--- a/lib/fluent/plugin/filter_obsolete_plugins.rb
+++ b/lib/fluent/plugin/filter_obsolete_plugins.rb
@@ -32,7 +32,7 @@ module Fluent
       def configure(conf)
         super
 
-        @obsolete_plugins = open(@obsolete_plugins_yml) do |io|
+        @obsolete_plugins = URI.open(@obsolete_plugins_yml) do |io|
           YAML.safe_load(io.read)
         end
 


### PR DESCRIPTION
Seems we can't use `Kernel#open` since Ruby 3.0.

```ruby
require "open-uri"
require "yaml"

OBSOLETE_PLUGINS_URL = "https://raw.githubusercontent.com/fluent/fluentd-website/master/scripts/obsolete-plugins.yml"

open(OBSOLETE_PLUGINS_URL)
```

* With Ruby 2.7
```
$ ruby -v open-uri.rb
ruby 2.7.8p225 (2023-03-30 revision 1f4d455848) [x86_64-linux]
open-uri.rb:6: warning: calling URI.open via Kernel#open is deprecated, call URI.open directly or use URI#open
```

* With Ruby 3.0
```
$ ruby -v open-uri.rb
ruby 3.0.7p220 (2024-04-23 revision 724a071175) [x86_64-linux]
open-uri.rb:6:in `initialize': No such file or directory @ rb_sysopen - https://raw.githubusercontent.com/fluent/fluentd-website/master/scripts/obsolete-plugins.yml (Errno::ENOENT)
        from open-uri.rb:6:in `open'
        from open-uri.rb:6:in `<main>'
```