### PR TITLE
Check whether obsolete for installed plugins

### DIFF
--- a/lib/fluent/plugin/obsolete_plugins_utils.rb
+++ b/lib/fluent/plugin/obsolete_plugins_utils.rb
@@ -28,8 +28,12 @@ class Fluent::Plugin::ObsoletePluginsUtils
     end
   end
 
+  def self.installed_plugins
+    Gem::Specification.find_all.select { |x| x.name =~ /^fluent(d|-(plugin|mixin)-.*)$/ }.map(&:name)
+  end
+
   def self.notify(logger, obsolete_plugins, raise_error: false)
-    plugins = Gem.loaded_specs.keys & obsolete_plugins.keys
+    plugins = Fluent::Plugin::ObsoletePluginsUtils.installed_plugins & obsolete_plugins.keys
     plugins.each do |name|
       logger.warn("#{name} is obsolete: #{obsolete_plugins[name].chomp}")
     end

--- a/test/plugin/test_filter_obsolete_plugins.rb
+++ b/test/plugin/test_filter_obsolete_plugins.rb
@@ -20,6 +20,10 @@ class ObsoletePluginsFilterTest < Test::Unit::TestCase
     ]
 
     test "no obsolete plugins" do
+      stub(Fluent::Plugin::ObsoletePluginsUtils).installed_plugins do
+        []
+      end
+
       d = create_driver(CONFIG_YAML)
       d.run(default_tag: "test") do
         d.feed({ message: "This is test message." })
@@ -32,12 +36,10 @@ class ObsoletePluginsFilterTest < Test::Unit::TestCase
     end
 
     test "obsolete plugins" do
-      mock(Gem).loaded_specs do
-        {
-          "fluent-plugin-tail-multiline" => nil,
-          "fluent-plugin-hostname" => nil
-        }
+      stub(Fluent::Plugin::ObsoletePluginsUtils).installed_plugins do
+        ["fluent-plugin-tail-multiline", "fluent-plugin-hostname"]
       end
+
       d = create_driver(CONFIG_YAML)
       d.run(default_tag: "test") do
         d.feed({ message: "This is test message." })
@@ -52,11 +54,8 @@ class ObsoletePluginsFilterTest < Test::Unit::TestCase
     end
 
     test "raise error when detect obsolete plugins" do
-      mock(Gem).loaded_specs do
-        {
-          "fluent-plugin-tail-multiline" => nil,
-          "fluent-plugin-hostname" => nil
-        }
+      stub(Fluent::Plugin::ObsoletePluginsUtils).installed_plugins do
+        ["fluent-plugin-tail-multiline", "fluent-plugin-hostname"]
       end
 
       ex = assert_raise(Fluent::ConfigError) do
@@ -72,6 +71,10 @@ class ObsoletePluginsFilterTest < Test::Unit::TestCase
     ]
 
     test "no obsolete plugins" do
+      stub(Fluent::Plugin::ObsoletePluginsUtils).installed_plugins do
+        []
+      end
+
       d = create_driver(CONFIG_JSON)
       d.run(default_tag: "test") do
         d.feed({ message: "This is test message." })
@@ -81,12 +84,10 @@ class ObsoletePluginsFilterTest < Test::Unit::TestCase
     end
 
     test "obsolete plugins" do
-      mock(Gem).loaded_specs do
-        {
-          "fluent-plugin-tail-multiline" => nil,
-          "fluent-plugin-hostname" => nil
-        }
+      stub(Fluent::Plugin::ObsoletePluginsUtils).installed_plugins do
+        ["fluent-plugin-tail-multiline", "fluent-plugin-hostname"]
       end
+
       d = create_driver(CONFIG_JSON)
       d.run(default_tag: "test") do
         d.feed({ message: "This is test message." })
@@ -100,11 +101,8 @@ class ObsoletePluginsFilterTest < Test::Unit::TestCase
     end
 
     test "raise error when detect obsolete plugins" do
-      mock(Gem).loaded_specs do
-        {
-          "fluent-plugin-tail-multiline" => nil,
-          "fluent-plugin-hostname" => nil
-        }
+      stub(Fluent::Plugin::ObsoletePluginsUtils).installed_plugins do
+        ["fluent-plugin-tail-multiline", "fluent-plugin-hostname"]
       end
 
       ex = assert_raise(Fluent::ConfigError) do

--- a/test/plugin/test_in_obsolete_plugins.rb
+++ b/test/plugin/test_in_obsolete_plugins.rb
@@ -21,6 +21,10 @@ class ObsoletePluginsInputTest < Test::Unit::TestCase
     ]
 
     test "no obsolete plugins" do
+      stub(Fluent::Plugin::ObsoletePluginsUtils).installed_plugins do
+        []
+      end
+
       d = create_driver(CONFIG_JSON)
       d.run
       assert_equal([], d.events)
@@ -28,12 +32,10 @@ class ObsoletePluginsInputTest < Test::Unit::TestCase
     end
 
     test "obsolete plugins" do
-      stub(Gem).loaded_specs do
-        {
-          "fluent-plugin-tail-multiline" => nil,
-          "fluent-plugin-hostname" => nil
-        }
+      stub(Fluent::Plugin::ObsoletePluginsUtils).installed_plugins do
+        ["fluent-plugin-tail-multiline", "fluent-plugin-hostname"]
       end
+
       d = create_driver(CONFIG_JSON)
       d.run
       assert_equal([], d.events)
@@ -45,11 +47,8 @@ class ObsoletePluginsInputTest < Test::Unit::TestCase
     end
 
     test "raise error when detect obsolete plugins" do
-      stub(Gem).loaded_specs do
-        {
-          "fluent-plugin-tail-multiline" => nil,
-          "fluent-plugin-hostname" => nil
-        }
+      stub(Fluent::Plugin::ObsoletePluginsUtils).installed_plugins do
+        ["fluent-plugin-tail-multiline", "fluent-plugin-hostname"]
       end
 
       ex = assert_raise(Fluent::ConfigError) do


### PR DESCRIPTION
Currently, it will checks only loaded plugins.
The plugins loaded after fluent-plugin-obsolete-plugins will not be checked.
fluent-plugin-obsolete-plugins is not always be loaded at last.

So, this PR will check the installed plugins instead of loaded.
