### PR TITLE
in_obsolete_plugins: support multi worker

### DIFF
--- a/lib/fluent/plugin/in_obsolete_plugins.rb
+++ b/lib/fluent/plugin/in_obsolete_plugins.rb
@@ -15,6 +15,10 @@ module Fluent
       desc "Raise error if obsolete plugins are detected"
       config_param :raise_error, :bool, default: false
 
+      def multi_workers_ready?
+        true
+      end
+
       def configure(conf)
         super
 

--- a/test/plugin/test_filter_obsolete_plugins.rb
+++ b/test/plugin/test_filter_obsolete_plugins.rb
@@ -14,6 +14,15 @@ class ObsoletePluginsFilterTest < Test::Unit::TestCase
     Timecop.return
   end
 
+  test "multi worker" do
+    config = %[
+      obsolete_plugins_yml #{fixture_path("obsolete-plugins.yml")}
+    ]
+
+    d = create_driver(config)
+    assert_true d.instance.multi_workers_ready?
+  end
+
   sub_test_case "obsolete_plugins_yml" do
     CONFIG_YAML = %[
       obsolete_plugins_yml #{fixture_path("obsolete-plugins.yml")}

--- a/test/plugin/test_in_obsolete_plugins.rb
+++ b/test/plugin/test_in_obsolete_plugins.rb
@@ -15,6 +15,15 @@ class ObsoletePluginsInputTest < Test::Unit::TestCase
     Timecop.return
   end
 
+  test "multi worker" do
+    config = %[
+      obsolete_plugins_yml #{fixture_path("obsolete-plugins.yml")}
+    ]
+
+    d = create_driver(config)
+    assert_true d.instance.multi_workers_ready?
+  end
+
   sub_test_case "plugins_json" do
     CONFIG_JSON = %[
       plugins_json #{fixture_path("plugins.json")}


### PR DESCRIPTION
If confiured using multi worker, `in_obsolete_plugins` causes following config error.

### config
```
<system>
  workers 2
</system>

<source>
  @type obsolete_plugins
</source>
```

### error
```
2025-08-27 17:12:31 +0900 [error]: config error file="/home/watson/prj/sandbox/fluentd/fluent.conf" error_class=Fluent::ConfigError error="Plugin 'obsolete_plugins' does not support multi workers configuration (Fluent::Plugin::ObsoletePluginsInput)"
```

This PR will solve above config error.